### PR TITLE
Add tile texture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 bin
+game.exe
+game-debug.exe

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,17 @@ linkOpenGL := -lglew32 -lglfw3 -lopengl32 -lgdi32
 .PHONY: build
 build: game.exe
 
+.PHONY: build-debug
+build-debug: game-debug.exe
+
 bin/%.o: src/%.cpp
 	g++ $< -std=c++11 -c -Iinc -o $@
-
+	
 game.exe: $(patsubst src/%.cpp,bin/%.o,$(wildcard src/*.cpp))
 	g++ $^ -o $@ -std=c++11 $(linkOpenGL)
+
+bin/%.o.dbg: src/%.cpp
+	g++ -g $< -std=c++11 -c -Iinc -o $@
+
+game-debug.exe: $(patsubst src/%.cpp,bin/%.o.dbg,$(wildcard src/*.cpp))
+	g++ -g $^ -o $@ -std=c++11 $(linkOpenGL)

--- a/inc/common.h
+++ b/inc/common.h
@@ -1,13 +1,31 @@
 #ifndef COMMON_H_DEFINED
 #define COMMON_H_DEFINED
-typedef struct tileID
+#include <string>
+#include <cstdio>
+#include <util_opengl.h>
+
+struct tileID
 {
     unsigned int line, column;
 };
 
-typedef struct tileProperties
+struct tileProperties
 {
     bool isNavigable;
+};
+
+struct texture_mapping
+{
+    NDC bottom_left;
+    NDC upper_left;
+    NDC upper_right;
+    NDC bottom_right;
+};
+
+struct Position2D
+{
+    float x;
+    float y;
 };
 
 #endif

--- a/inc/singleton.h
+++ b/inc/singleton.h
@@ -1,0 +1,22 @@
+#ifndef SINGLETON_H_INCLUDED
+#define SINGLETON_H_INCLUDED
+#include <string>
+
+template <class T>
+class singleton
+{
+protected:
+    singleton() noexcept = default;
+    singleton(const singleton &) = delete;
+    singleton &operator=(const singleton &) = delete;
+    virtual ~singleton() = default;
+
+public:
+    static T &get_instance() noexcept(std::is_nothrow_constructible<T>::value)
+    {
+        static T instance;
+        return instance;
+    }
+};
+
+#endif

--- a/inc/texture.h
+++ b/inc/texture.h
@@ -1,0 +1,22 @@
+#ifndef TEXTURE_H_INCLUDED
+#define TEXTURE_H_INCLUDED
+#include <string>
+class texture
+{
+private:
+    int width, height, nChannels, dataSize;
+    unsigned char *data;
+    std::string path;
+
+public:
+    texture(std::string path);
+    ~texture();
+    void freeData();
+    int getWidth() { return this->width; }
+    int getHeight() { return this->height; }
+    int getNChannels() { return this->nChannels; }
+    unsigned char *getDataPtr() { return this->data; }
+    std::string getPath() { return this->path; }
+};
+
+#endif

--- a/inc/tile_shader.h
+++ b/inc/tile_shader.h
@@ -1,0 +1,46 @@
+#ifndef TILE_SHADER_H_INCLUDED
+#define TILE_SHADER_H_INCLUDED
+#include <vector>
+#include <string>
+#include <singleton.h>
+#include <util_opengl.h>
+#include <common.h>
+#include <texture.h>
+
+struct textureData
+{
+    unsigned int VAO, textureID;
+};
+
+//tile_shader inherits the singleton behavior through CRTP
+class tile_shader : public singleton<tile_shader>
+{
+    friend class singleton<tile_shader>;
+
+private:
+    tile_shader();
+    ~tile_shader();
+    unsigned int newDefaultVAO(texture_mapping mapping, texture &tex, unsigned int positionVBO);
+    unsigned int
+        shaderProgramID,
+        EBO,
+        diamondVBO, squareVBO,
+        positionXLocation, positionYLocation,
+        offsetXLocation, offsetYLocation;
+    std::vector<textureData> textures;
+
+public:
+    unsigned int newDiamondTexture(texture_mapping mapping, texture &tex);
+    unsigned int newSquareTexture(texture_mapping mapping, texture &tex);
+    void bindTexture(unsigned int textureID);
+    void draw();
+    void setOriginPosition(NDC originPosition);
+    void setOriginPosition(float posX, float posY);
+    void setOriginPositionX(float posX);
+    void setOriginPositionY(float posY);
+    void setTextureOffset(float offsetX, float offsetY);
+    void setTextureOffsetX(float offsetX);
+    void setTextureOffsetY(float offsetY);
+};
+
+#endif

--- a/inc/tile_texture.h
+++ b/inc/tile_texture.h
@@ -1,0 +1,24 @@
+#ifndef TILE_TEXTURE_H_INCLUDED
+#define TILE_TEXTURE_H_INCLUDED
+#include <texture.h>
+#include <string>
+#include <tile_shader.h>
+#include <common.h>
+
+class tile_texture
+{
+private:
+    int tileWidth, tileHeight, wQtd, hQtd;
+    texture tex;
+    tile_shader *shader;
+    unsigned int textureID;
+
+public:
+    // path is the path for the image to be loaded, wQtd and hQtd are the
+    // number of tiles along the width and height lengths, respectively.
+    tile_texture(std::string path, int wQtd, int hQtd);
+    ~tile_texture(){};
+    void draw(tileID tile, NDC pos);
+};
+
+#endif

--- a/inc/util_opengl.h
+++ b/inc/util_opengl.h
@@ -1,0 +1,19 @@
+#ifndef UTIL_OPENGL_H_DEFINED
+#define UTIL_OPENGL_H_DEFINED
+#include <string>
+
+unsigned int createVertexShader(const char *path);
+unsigned int createFragShader(const char *path);
+unsigned int createShader(unsigned int type, const char *path);
+std::string testCompileProgram(unsigned int program);
+// void testCompileProgram(unsigned int program);
+unsigned int createVBO(float buffer[], unsigned int size);
+unsigned int createAndBindVAO();
+
+//normalized device coordinate
+struct NDC
+{
+    float x, y;
+};
+
+#endif

--- a/shaders/tile_shader.frag
+++ b/shaders/tile_shader.frag
@@ -1,0 +1,14 @@
+#version 330 core
+out vec4 FragColor;
+  
+in vec2 TexCoord;
+
+uniform sampler2D ourTexture;
+uniform float offsetx;
+uniform float offsety;
+
+void main()
+{
+    vec2 vt = vec2(TexCoord.x + offsetx, TexCoord.y + offsety);
+    FragColor = texture(ourTexture, vt);
+}

--- a/shaders/tile_shader.vert
+++ b/shaders/tile_shader.vert
@@ -1,0 +1,17 @@
+#version 330 core
+layout (location = 0) in vec3 aPos;
+layout (location = 1) in vec2 aTexCoord;
+uniform mat4 rotationMatrix;
+
+out vec2 TexCoord;
+
+uniform float positionx;
+uniform float positiony;
+
+void main()
+{
+    // vec4 pos = rotationMatrix * vec4(aPos, 1.0);
+    vec4 pos = vec4(aPos, 1.0);
+    gl_Position = vec4(pos.x + positionx,pos.y + positiony,pos.z,pos.w);
+    TexCoord = aTexCoord;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,73 @@
 #include <bits/stdc++.h>
+#define GLEW_STATIC
+#include "GL/glew.h"
+#include "GLFW/glfw3.h"
+#include "glm/glm.hpp"
+
+#include <tile_texture.h>
+#include <util_opengl.h>
+#include <timer.h>
+
+#define WINDOW_WIDTH 1000
+#define WINDOW_HEIGHT 500
 
 using namespace std;
+
+void framebuffer_size_callback(GLFWwindow *window, int width, int height)
+{
+    glViewport(0, 0, width, height);
+}
+
+void processInput(GLFWwindow *window)
+{
+    if (glfwGetKey(window, GLFW_KEY_ESCAPE) == GLFW_PRESS)
+        glfwSetWindowShouldClose(window, true);
+}
+
 int main()
 {
+    if (!glfwInit())
+    {
+        cout << "failed to start GLFW3" << endl;
+        throw;
+    }
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+
+    GLFWwindow *window = glfwCreateWindow(WINDOW_WIDTH, WINDOW_HEIGHT, "Ship fight", NULL, NULL);
+    if (window == NULL)
+    {
+        std::cout << "Failed to create GLFW window" << std::endl;
+        glfwTerminate();
+        return -1;
+    }
+    glfwMakeContextCurrent(window);
+
+    glewExperimental = GL_TRUE;
+    glewInit();
+
+    glfwSetFramebufferSizeCallback(window, framebuffer_size_callback);
+
+    glEnable(GL_BLEND);
+    glEnable(GL_TEXTURE_2D);
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+    glViewport(0, 0, WINDOW_WIDTH, WINDOW_HEIGHT);
+
+    //create the tile_texture for the main tile set
+    tile_texture avalonTile("./texture/avalon.png", 27, 24);
+    //timer maintains an update rate of 60Hz max
+    timer t(60);
+    while (!glfwWindowShouldClose(window))
+    {
+        t.update();
+        processInput(window);
+        glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT);
+        avalonTile.draw(tileID{line : 0, column : 0}, NDC{x : 0, y : 0});
+        glfwSwapBuffers(window);
+        glfwPollEvents();
+    }
+    glfwTerminate();
 }

--- a/src/texture.cpp
+++ b/src/texture.cpp
@@ -1,0 +1,32 @@
+#include <texture.h>
+#include <iostream>
+#define STB_IMAGE_IMPLEMENTATION
+#include "stb_image.h"
+
+texture::texture(std::string path)
+{
+    stbi_set_flip_vertically_on_load(true);
+    this->path = path;
+    this->data = stbi_load(path.c_str(), &this->width, &this->height, &this->nChannels, 0);
+    if (this->data == NULL)
+    {
+        std::cout << "error reading file \"" << path << "\"" << std::endl;
+        throw;
+    }
+    this->dataSize = this->width * this->height * this->nChannels * sizeof(this->data[0]);
+}
+
+void texture::freeData()
+{
+    if (this->data != nullptr)
+    {
+        stbi_image_free(this->data);
+        this->data = nullptr;
+    }
+}
+
+texture::~texture()
+{
+
+    this->freeData();
+}

--- a/src/tile_shader.cpp
+++ b/src/tile_shader.cpp
@@ -1,0 +1,200 @@
+#include <iostream>
+#include <tile_shader.h>
+#include <util_opengl.h>
+#define GLEW_STATIC
+#include "GL/glew.h"
+#include "GLFW/glfw3.h"
+
+//defines the name of the uniform that controls the origin position for the to be drawn (NDC coordinates)
+#define POSITION_X_UNIFORM "positionx"
+#define POSITION_Y_UNIFORM "positiony"
+
+//defines the name of the uniform that controls the offset for maping textures (0 to 1.0f)
+#define OFFSET_X_UNIFORM "offsetx"
+#define OFFSET_Y_UNIFORM "offsety"
+
+//diamond tile size
+#define DIAMOND_TILE_WIDTH 0.25f
+#define DIAMOND_TILE_HEIGHT 0.15f
+
+#define SQUARE_TILE_SIZE 0.25f
+
+//size of the buffer containing the NDC coordinates for the shapes. No sense changing this without adding more points
+#define VERTEX_DATA_BUFFER_SIZE 12
+
+//size of the buffer containing the NDC coordinates for a texture mapping
+#define TEXTURE_MAPPING_BUFFER_SIZE 8
+
+void textureMappingToBuffer(texture_mapping mapping, float buffer[]);
+void fillDiamondShapeBuffer(float buffer[], float width, float height);
+void fillRectangleShapeBuffer(float buffer[], float width, float height);
+
+tile_shader::tile_shader()
+{
+    //load the shaders, create a shader program linking them, make sure it compiles
+    unsigned int vertShaderID = createVertexShader("./shaders/tile_shader.vert");
+    unsigned int fragShaderID = createFragShader("./shaders/tile_shader.frag");
+    this->shaderProgramID = glCreateProgram();
+    unsigned int p = this->shaderProgramID;
+    glAttachShader(p, vertShaderID);
+    glAttachShader(p, fragShaderID);
+    glLinkProgram(p);
+    testCompileProgram(p);
+    glUseProgram(p);
+    glDeleteShader(vertShaderID);
+    glDeleteShader(fragShaderID);
+
+    //get the location for all uniforms we're using in the shaders
+    this->positionXLocation = glGetUniformLocation(p, POSITION_X_UNIFORM);
+    this->positionYLocation = glGetUniformLocation(p, POSITION_Y_UNIFORM);
+    this->offsetXLocation = glGetUniformLocation(p, OFFSET_X_UNIFORM);
+    this->offsetYLocation = glGetUniformLocation(p, OFFSET_Y_UNIFORM);
+
+    // create VBO for the "diamond" shape, bind the buffer data
+    float diamondShapeBuffer[VERTEX_DATA_BUFFER_SIZE];
+    fillDiamondShapeBuffer(diamondShapeBuffer, DIAMOND_TILE_WIDTH, DIAMOND_TILE_HEIGHT);
+    this->diamondVBO = createVBO(diamondShapeBuffer, VERTEX_DATA_BUFFER_SIZE);
+
+    //create VBO for the square shape, bind the buffer data
+    float squareShapeBuffer[VERTEX_DATA_BUFFER_SIZE];
+    fillRectangleShapeBuffer(squareShapeBuffer, SQUARE_TILE_SIZE, SQUARE_TILE_SIZE);
+    this->squareVBO = createVBO(squareShapeBuffer, VERTEX_DATA_BUFFER_SIZE);
+
+    //create EBO.
+    unsigned int indices[] = {
+        0, 1, 3,
+        1, 2, 3};
+    glGenBuffers(1, &this->EBO);
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->EBO);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices, GL_STATIC_DRAW);
+}
+
+tile_shader::~tile_shader()
+{
+    //TODO: cleanup shader resources
+}
+
+unsigned int tile_shader::newDiamondTexture(texture_mapping mapping, texture &tex)
+{
+    return newDefaultVAO(mapping, tex, this->diamondVBO);
+}
+
+unsigned int tile_shader::newSquareTexture(texture_mapping mapping, texture &tex)
+{
+    return newDefaultVAO(mapping, tex, this->squareVBO);
+}
+
+unsigned int tile_shader::newDefaultVAO(texture_mapping mapping, texture &tex, unsigned int positionVBO)
+{
+    //create VAO and bind our EBO
+    unsigned int VAO = createAndBindVAO();
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, this->EBO);
+
+    //bind positionVBO to VAO. That's location 0 in vertex shader
+    glBindBuffer(GL_ARRAY_BUFFER, positionVBO);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 3 * sizeof(float), (void *)0);
+    glEnableVertexAttribArray(0);
+
+    //create and bind textureVBO to VAO. That's location 1 in vertex shader, used in frag shader
+    float buffer[TEXTURE_MAPPING_BUFFER_SIZE];
+    textureMappingToBuffer(mapping, buffer);
+    unsigned int textureVBO = createVBO(buffer, TEXTURE_MAPPING_BUFFER_SIZE);
+    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 2 * sizeof(float), (void *)0);
+    glEnableVertexAttribArray(1);
+
+    unsigned int textureID;
+    glGenTextures(1, &textureID);
+    glBindTexture(GL_TEXTURE_2D, textureID);
+    unsigned int format = tex.getNChannels() == 4 ? GL_RGBA : GL_RGB;
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    glTexImage2D(GL_TEXTURE_2D, 0, format, tex.getWidth(), tex.getHeight(), 0, format, GL_UNSIGNED_BYTE, tex.getDataPtr());
+
+    unsigned int id = this->textures.size();
+    this->textures.push_back(textureData{VAO : VAO, textureID : textureID});
+    return id;
+}
+
+void tile_shader::bindTexture(unsigned int id)
+{
+    textureData texture = this->textures[id];
+    glBindTexture(GL_TEXTURE_2D, texture.textureID);
+    glBindVertexArray(texture.VAO);
+}
+
+void tile_shader::draw()
+{
+    glUseProgram(this->shaderProgramID);
+    // TODO: assert that the currently bound VAO is one created by this shader
+    glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);
+}
+
+//uniform setters
+void tile_shader::setOriginPositionX(float posX)
+{
+    glUniform1f(this->positionXLocation, posX);
+}
+void tile_shader::setOriginPositionY(float posY)
+{
+    glUniform1f(this->positionYLocation, posY);
+}
+void tile_shader::setTextureOffsetX(float offsetX)
+{
+    glUniform1f(this->offsetXLocation, offsetX);
+}
+void tile_shader::setTextureOffsetY(float offsetY)
+{
+    glUniform1f(this->offsetYLocation, offsetY);
+}
+
+void textureMappingToBuffer(texture_mapping mapping, float buffer[])
+{
+    float b[TEXTURE_MAPPING_BUFFER_SIZE] = {
+        mapping.bottom_left.x, mapping.bottom_left.y,
+        mapping.upper_left.x, mapping.upper_right.y,
+        mapping.upper_right.x, mapping.upper_right.y,
+        mapping.bottom_right.x, mapping.bottom_right.y};
+    for (int i = 0; i < TEXTURE_MAPPING_BUFFER_SIZE; i++)
+        buffer[i] = b[i];
+}
+
+void fillDiamondShapeBuffer(float buffer[], float width, float height)
+{
+    float b[VERTEX_DATA_BUFFER_SIZE] = {
+        -width / 2, 0, 0,
+        0, height / 2, 0,
+        width / 2, 0, 0,
+        0, -height / 2, 0};
+    for (int i = 0; i < VERTEX_DATA_BUFFER_SIZE; i++)
+        buffer[i] = b[i];
+}
+
+void fillRectangleShapeBuffer(float buffer[], float width, float height)
+{
+    float b[VERTEX_DATA_BUFFER_SIZE] = {
+        -width / 2, -height / 2, 0,
+        -width / 2, height / 2, 0,
+        width / 2, height / 2, 0,
+        width / 2, -height / 2, 0};
+    for (int i = 0; i < VERTEX_DATA_BUFFER_SIZE; i++)
+        buffer[i] = b[i];
+}
+
+//uniform helper setters
+void tile_shader::setOriginPosition(NDC originPosition)
+{
+    this->setOriginPositionX(originPosition.x);
+    this->setOriginPositionY(originPosition.y);
+}
+void tile_shader::setOriginPosition(float posX, float posY)
+{
+    this->setOriginPositionX(posX);
+    this->setOriginPositionY(posY);
+}
+void tile_shader::setTextureOffset(float offsetX, float offsetY)
+{
+    this->setTextureOffsetX(offsetX);
+    this->setTextureOffsetY(offsetY);
+}

--- a/src/tile_texture.cpp
+++ b/src/tile_texture.cpp
@@ -30,7 +30,7 @@ tile_texture::tile_texture(std::string path, int wQtd, int hQtd) : tex(path)
     this->tileHeight = this->tex.getHeight() / hQtd;
 
     this->shader = &tile_shader::get_instance();
-    texture_mapping textureMapping = createTextureMapping(1.0f / (float)this->wQtd, 1.0f / (float)this->tileHeight);
+    texture_mapping textureMapping = createTextureMapping(1.0f / (float)this->wQtd, 1.0f / (float)this->hQtd);
     this->textureID = this->shader->newDiamondTexture(textureMapping, this->tex);
     this->tex.freeData();
 }

--- a/src/tile_texture.cpp
+++ b/src/tile_texture.cpp
@@ -1,0 +1,62 @@
+#include <tile_texture.h>
+#include <tile_shader.h>
+#include <iostream>
+
+texture_mapping createTextureMapping(float width, float height);
+
+tile_texture::tile_texture(std::string path, int wQtd, int hQtd) : tex(path)
+{
+    if (wQtd < 1 || hQtd < 1)
+    {
+        std::cout << "should have at least one tile in both horizontal and vertical directions" << std::endl;
+        throw;
+    }
+
+    if (this->tex.getWidth() % wQtd != 0)
+    {
+        std::cout << "image width should be a multiple of tile width" << std::endl;
+        throw;
+    }
+
+    if (this->tex.getHeight() % hQtd != 0)
+    {
+        std::cout << "image height should be a multiple of tile height" << std::endl;
+        throw;
+    }
+
+    this->wQtd = wQtd;
+    this->hQtd = hQtd;
+    this->tileWidth = this->tex.getWidth() / wQtd;
+    this->tileHeight = this->tex.getHeight() / hQtd;
+
+    this->shader = &tile_shader::get_instance();
+    texture_mapping textureMapping = createTextureMapping(1.0f / (float)this->wQtd, 1.0f / (float)this->tileHeight);
+    this->textureID = this->shader->newDiamondTexture(textureMapping, this->tex);
+    this->tex.freeData();
+}
+
+void tile_texture::draw(tileID tile, NDC pos)
+{
+    if (tile.column >= this->wQtd)
+        throw "tried to draw a tile column outside the texture range\n";
+    if (tile.line >= this->hQtd)
+        throw "tried to draw a tile line outside the texture range\n";
+    this->shader->setOriginPosition(pos);
+    float tileBottomLeftCornerX = tile.column * this->tileWidth;
+    float tileBottomLeftCornerY = (this->hQtd - tile.line - 1) * this->tileHeight;
+    this->shader->setTextureOffsetX((float)tileBottomLeftCornerX / (float)this->tex.getWidth());
+    this->shader->setTextureOffsetY((float)tileBottomLeftCornerY / (float)this->tex.getHeight());
+    this->shader->bindTexture(this->textureID);
+    this->shader->draw();
+}
+
+texture_mapping createTextureMapping(float width, float height)
+{
+    texture_mapping mapping = {
+        bottom_left : {0, 0},
+        upper_left : {0, height},
+        upper_right : {width, height},
+        bottom_right : {width, 0},
+    };
+    return mapping;
+}

--- a/src/util_opengl.cpp
+++ b/src/util_opengl.cpp
@@ -46,7 +46,6 @@ std::string testCompileProgram(unsigned int program)
     int success;
     char infoLog[512];
     glGetProgramiv(program, GL_COMPILE_STATUS, &success);
-    std::cout << "success: " << success << std::endl;
     if (!success)
     {
         glGetProgramInfoLog(program, 512, NULL, infoLog);
@@ -62,7 +61,6 @@ std::string testCompileProgram(unsigned int program)
 //     int success;
 //     char infoLog[512];
 //     glGetProgramiv(program, GL_COMPILE_STATUS, &success);
-//     std::cout << "success: " << success << std::endl;
 //     if (!success)
 //     {
 //         glGetProgramInfoLog(program, 512, NULL, infoLog);

--- a/src/util_opengl.cpp
+++ b/src/util_opengl.cpp
@@ -1,0 +1,120 @@
+#include <util_opengl.h>
+#include <bits/stdc++.h>
+#define GLEW_STATIC
+#include "GL/glew.h"
+#include "GLFW/glfw3.h"
+
+std::string readFile(const char *filePath)
+{
+    std::string content;
+    std::ifstream fileStream(filePath, std::ios::in);
+
+    if (!fileStream.is_open())
+    {
+        std::cerr << "Could not read file " << filePath << ". File does not exist." << std::endl;
+        return "";
+    }
+
+    std::string line = "";
+    while (!fileStream.eof())
+    {
+        std::getline(fileStream, line);
+        content.append(line + "\n");
+    }
+
+    fileStream.close();
+    return content;
+}
+
+void testCompileShader(unsigned int shader)
+{
+    int success;
+    char infoLog[512];
+    glGetShaderiv(shader, GL_COMPILE_STATUS, &success);
+    if (!success)
+    {
+        glGetShaderInfoLog(shader, 512, NULL, infoLog);
+        std::cout << "shader compilation failed" << std::endl
+                  << infoLog << std::endl;
+        throw;
+    }
+}
+
+//TODO: make this a void function (for some reason the glProgram doesn't compile if I change the return type)
+std::string testCompileProgram(unsigned int program)
+{
+    int success;
+    char infoLog[512];
+    glGetProgramiv(program, GL_COMPILE_STATUS, &success);
+    std::cout << "success: " << success << std::endl;
+    if (!success)
+    {
+        glGetProgramInfoLog(program, 512, NULL, infoLog);
+        std::cout << "program compilation failed" << std::endl
+                  << infoLog << std::endl;
+        throw;
+    }
+    return "";
+}
+
+// void testCompileProgram(unsigned int program)
+// {
+//     int success;
+//     char infoLog[512];
+//     glGetProgramiv(program, GL_COMPILE_STATUS, &success);
+//     std::cout << "success: " << success << std::endl;
+//     if (!success)
+//     {
+//         glGetProgramInfoLog(program, 512, NULL, infoLog);
+//         std::cout << "program compilation failed" << std::endl
+//                   << infoLog << std::endl;
+//         throw;
+//     }
+// }
+
+unsigned int createVertexShader(const char *path)
+{
+    return createShader(GL_VERTEX_SHADER, path);
+}
+
+unsigned int createFragShader(const char *path)
+{
+    return createShader(GL_FRAGMENT_SHADER, path);
+}
+
+unsigned int createShader(unsigned int type, const char *path)
+{
+    std::string src = readFile(path);
+    const char *src_ptr = src.c_str();
+    unsigned int shaderID;
+    shaderID = glCreateShader(type);
+    glShaderSource(shaderID, 1, &src_ptr, NULL);
+    glCompileShader(shaderID);
+    try
+    {
+        testCompileShader(shaderID);
+    }
+    catch (std::string e)
+    {
+        std::cout << path << ": " << e;
+        throw;
+    }
+    return shaderID;
+}
+
+unsigned int createVBO(float buffer[], unsigned int size)
+{
+    unsigned int VBO;
+    glGenBuffers(1, &VBO);
+    glBindBuffer(GL_ARRAY_BUFFER, VBO);
+    glBufferData(GL_ARRAY_BUFFER, size * sizeof(float), buffer, GL_STATIC_DRAW);
+    return VBO;
+}
+
+unsigned int createAndBindVAO()
+{
+    unsigned int VAO;
+    glGenVertexArrays(1, &VAO);
+    glBindVertexArray(VAO);
+    return VAO;
+}


### PR DESCRIPTION
Essa PR adiciona uma serie de classes para carregar um imagem e desenhar um tile dessa imagem na tela: 
* A classe `tile_shader` é responsável por interagir com os shaders, nenhuma informação sobre eles deve ser conhecida por outras classes. Como não faz sentido haver varias instâncias do shader, `tile_shader` é um singleton, herdando esse comportamento da classe `singlenton` através de [CRTP](https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern).
* A classe `texture` é responsável por carregar uma imagem
* A classe `tile_texture` é responsável por desenhar na tela um tile. Para carregar a imagem ela usa `texture`, e para desenhar os tiles ela usa `tile_shader`

Foram feitas algumas alterações no `main` para mostrar como usar a classe, porém eventualmente seria melhor ter todas as chamadas de opengl fora do `main`