### PR TITLE
Update tile_map.cpp

### DIFF
--- a/src/tile_map.cpp
+++ b/src/tile_map.cpp
@@ -29,7 +29,7 @@ tileID tile_map::get(unsigned int line, unsigned int column){
     unsigned int tile = this->tilesScenario[line][column];
 
     if(this->tsx.tileList[tile].hasAnimation){
-        double elapsedAnimation = fmod(this->t->getElapsedTime(),this->tsx.tileList[tile].period);
+        double elapsedAnimation = fmod(this->t->getTime() * 1000,this->tsx.tileList[tile].period);
         unsigned int frame = 0;
         while((elapsedAnimation = elapsedAnimation - this->tsx.tileList[tile].animation_tile_id_duration[frame])>=0){
             frame++;


### PR DESCRIPTION
Alterado parte do método get da classe tile_map, pois estava considerando o getTime como retornando  o tempo decorrido em milisegundos sendo que estava retornando em segundos, levando minutos para trocar os tiles e compor a animação.